### PR TITLE
Fix dimname of DimArray

### DIFF
--- a/src/axisarrays/dimensionaldata.jl
+++ b/src/axisarrays/dimensionaldata.jl
@@ -1,6 +1,7 @@
 using .DimensionalData: DimArray, DimensionalData, data, Dim, metadata
 
 _dname(::DimensionalData.Dim{N}) where N = N
+_dname()
 dimname(x::DimArray, i) = _dname(DimensionalData.dims(x)[i])
 
 


### PR DESCRIPTION
This enables dimname for other subtypes of DimensionalData.Dimension.
This fix enables to use a DimArray from DimensionalData in a YAXArray mapCube call.

